### PR TITLE
Etudes, Carols, and Missing Gear

### DIFF
--- a/Singer/README.md
+++ b/Singer/README.md
@@ -43,7 +43,9 @@ To turn a song off:
 	e.g. //sing madrigal 0 - sets number of madrigals to 0 madrigals will not be used.*
 	
 	
-*[buff] name of buff, currently supports all bard buffs excluding etudes and carols
+*[buff] name of buff, currently supports all bard buffs 
     e.g march, minuet, madrigal, scherzo, prelude, ballad, mazurka are all valid buff names
+    Note: Etudes and Carols are a bit different. If you want STR Etude you would do setude, DEX deteude, VIT vetude, etc etc
+          For Carols if you wanted Fire Carol you would do fcarol, ice icarol, etc etc. With one exception Lightning Carol is tcarol as in Thunder Resistance bcause there is also Light Carol which is lcarol.
 	
 **[song] name of song as it appears in game, not case sensitive.

--- a/Singer/Singer.lua
+++ b/Singer/Singer.lua
@@ -1,7 +1,7 @@
 _addon.author = 'Ivaar'
 _addon.commands = {'Singer','sing'}
 _addon.name = 'Singer'
-_addon.version = '1.19.10.09'
+_addon.version = '1.20.01.19'
 
 require('luau')
 require('pack')

--- a/Singer/sing_get.lua
+++ b/Singer/sing_get.lua
@@ -21,6 +21,21 @@ get.songs = {
     sirvente = {'Foe Sirvente'},
     dirge = {'Adventurer\'s Dirge'},
     scherzo = {'Sentinel\'s Scherzo'},
+    setude = {'Herculean Etude','Sinewy Etude'},
+    detude = {'Uncanny Etude','Dextrous Etude'},
+    vetude = {'Vital Etude','Vivacious Etude'},
+    aetude = {'Swift Etude','Quick Etude'},
+    ietude = {'Sage Etude','Learned Etude'},
+    metude = {'Logical Etude','Spirited Etude'},
+    cetude = {'Bewitching Etude','Enchanting Etude'},
+    fcarol = {'Fire Carol','Fire Carol II'},
+    icarol = {'Ice Carol','Ice Carol II'},
+    wcarol = {'Wind Carol','Wind Carol II'},
+    ecarol = {'Earth Carol','Earth Carol II'},
+    tcarol = {'Lightning Carol','Lightning Carol II'},
+    wcarol = {'Water Carol','Water Carol II'},
+    lcarol = {'Light Carol','Light Carol II'},
+    dcarol = {'Dark Carol','Dark Carol II'},
     }
 
 local song = {

--- a/Singer/song_timers.lua
+++ b/Singer/song_timers.lua
@@ -85,6 +85,14 @@ local equip_mods = {
     [27429] = {Scherzo=0.1},    -- 'Fili Cothurnes',
     [27430] = {Scherzo=0.1},    -- 'Fili Cothurnes +1',
     [26255] = {Madrigal=0.1,Prelude=0.1}, -- 'Intarabus\'s Cape',
+    [25561] = {Etude=0.1},      -- 'Mousai Turban',
+    [25562] = {Etude=0.2},      -- 'Mousai Turban +1',
+    [25988] = {Carol=0.1},      -- 'Mousai Gages',
+    [25989] = {Carol=0.2},      -- 'Mousai Gages +1',
+    [25901] = {Minne=0.1},      -- 'Mousai Seraweels',
+    [25902] = {Minne=0.2},      -- 'Mousai Seraweels +1',
+    [25968] = {Mambo=0.1},      -- 'Mousai Crackows',
+    [25969] = {Mambo=0.2},      -- 'Mousai Crackows +1',
     }
 
 local slots = {'main','sub','range','head','neck','body','hands','legs','feet','back'}


### PR DESCRIPTION
Carols are lower tier first because most want the increased resistance vs increased nullification of tier II.